### PR TITLE
change `Box<Error>` to `Box<dyn Error>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! ```no_run
 //! use std::{fs, error::Error};
 //! use err_ctx::ResultExt;
-//! fn run() -> Result<(), Box<Error>> {
+//! fn run() -> Result<(), Box<dyn Error>> {
 //!     // An error here might display as "reading foo.txt: No such file or directory"
 //!     let data = fs::read("foo.txt").ctx("reading foo.txt")?;
 //!     // ...


### PR DESCRIPTION
Error is a trait and trait objects should be prefixed with `dyn` to avoid confusion with `Box<Struct>`. 